### PR TITLE
fix: suppress invalid singal errors

### DIFF
--- a/src/node/interceptor.ts
+++ b/src/node/interceptor.ts
@@ -59,7 +59,9 @@ class Interceptor {
 
     for ( const signal of Signals ) {
 
-      process.once ( signal, () => this.exit ( signal ) );
+      try {
+        process.once ( signal, () => this.exit ( signal ) );
+      } catch {}
 
     }
 


### PR DESCRIPTION
I got `error: Uncaught (in promise) TypeError: Invalid signal : SIGPOLL` error on Codespaces (Ubuntu 20). I checked signal-exit source, and they also do [the same](https://github.com/tapjs/signal-exit/blob/03dd77a96caa309c6a02c59274d58c812a2dce45/index.js#L157-L161).