### PR TITLE
Add license field to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "repository": "github:fabiospampinato/when-exit",
   "description": "Execute a function right before the process, or the browser's tab, is about to exit.",
   "version": "2.1.3",
+  "license": "MIT",
   "type": "module",
   "main": "dist/node/index.js",
   "types": "./dist/node/index.d.ts",


### PR DESCRIPTION
Specify the license under which the project is available in the package.json so that it can be displayed on [npmjs.org](https://www.npmjs.com/package/when-exit) and used by automated tooling for license compliance.

See <https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license> for documentation about this field.