### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "repository": "github:fabiospampinato/when-exit",
   "description": "Execute a function right before the process, or the browser's tab, is about to exit.",
   "version": "2.1.3",
+  "license": "MIT",
   "type": "module",
   "main": "dist/node/index.js",
   "types": "./dist/node/index.d.ts",


### PR DESCRIPTION
Some tools like for example [LicenseFinder](https://github.com/pivotal/LicenseFinder) rely on the license property from package.json. If not present, the license is reported as unknown