### PR TITLE
Add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "when-exit",
   "repository": "github:fabiospampinato/when-exit",
   "description": "Execute a function right before the process, or the browser's tab, is about to exit.",
+  "license": "MIT",
   "version": "2.1.3",
   "type": "module",
   "main": "dist/node/index.js",


### PR DESCRIPTION
So that the license properly displays on npmjs.com and is detected by automated tooling